### PR TITLE
Fix fonts for GTK 4 applications

### DIFF
--- a/etc/skel/.config/gtk-4.0/setttings.ini
+++ b/etc/skel/.config/gtk-4.0/setttings.ini
@@ -1,0 +1,2 @@
+[Settings]
+gtk-hint-font-metrics=1


### PR DESCRIPTION
See: https://wiki.archlinux.org/title/GTK#Text_in_GTK_4_applications_is_blurry_or_renders_incorrectly