### PR TITLE
Update favorite-apps .desktop entry for Shelly

### DIFF
--- a/etc/dconf/db/local.d/00-cachyos.conf
+++ b/etc/dconf/db/local.d/00-cachyos.conf
@@ -9,4 +9,4 @@ numlock-state=true
 tap-to-click=true
 
 [org/gnome/shell]
-favorite-apps=['firefox.desktop', 'org.gnome.Ptyxis.desktop', 'shelly.desktop', 'org.gnome.Nautilus.desktop', 'org.gnome.TextEditor.desktop', 'org.gnome.SystemMonitor.desktop', 'cachyos-hello.desktop', 'org.gnome.Settings.desktop']
+favorite-apps=['firefox.desktop', 'org.gnome.Ptyxis.desktop', 'com.shellyorg.shelly.desktop', 'org.gnome.Nautilus.desktop', 'org.gnome.TextEditor.desktop', 'org.gnome.SystemMonitor.desktop', 'cachyos-hello.desktop', 'org.gnome.Settings.desktop']


### PR DESCRIPTION
In a recent update, for improved compatibility, the .desktop name changed from `shelly.desktop` to `com.shellyorg.shelly.desktop`. Updates accordingly for favourite-apps.