### PR TITLE
Update system monitor for favorite apps

### DIFF
--- a/etc/dconf/db/local.d/00-cachyos.conf
+++ b/etc/dconf/db/local.d/00-cachyos.conf
@@ -9,4 +9,4 @@ numlock-state=true
 tap-to-click=true
 
 [org/gnome/shell]
-favorite-apps=['firefox.desktop', 'org.gnome.Ptyxis.desktop', 'com.shellyorg.shelly.desktop', 'org.gnome.Nautilus.desktop', 'org.gnome.TextEditor.desktop', 'org.gnome.SystemMonitor.desktop', 'cachyos-hello.desktop', 'org.gnome.Settings.desktop']
+favorite-apps=['firefox.desktop', 'org.gnome.Ptyxis.desktop', 'com.shellyorg.shelly.desktop', 'org.gnome.Nautilus.desktop', 'org.gnome.TextEditor.desktop', 'net.nokyan.Resources.desktop', 'cachyos-hello.desktop', 'org.gnome.Settings.desktop']


### PR DESCRIPTION
GNOME System Monitor has been replaced by Resources on new installations. This PR updates the favourite apps to point to the .desktop of the new replacement.